### PR TITLE
Create docker image by building code instead of copy dlls externally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,27 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+WORKDIR /build
 
-COPY src/Faforever.Qai/bin/Release/net5.0/publish/ App/
-WORKDIR /App
+COPY ./Faforever.Qai.sln ./NuGet.config  ./
+
+# First copy all csproj, a bit ugly. Is there a better way? 
+COPY ./src/Faforever.Qai/Faforever.Qai.csproj ./src/Faforever.Qai/Faforever.Qai.csproj
+COPY ./src/Faforever.Qai.Core/Faforever.Qai.Core.csproj ./src/Faforever.Qai.Core/Faforever.Qai.Core.csproj
+COPY ./src/Faforever.Qai.Database.Setup/Faforever.Qai.Database.Setup.csproj ./src/Faforever.Qai.Database.Setup/Faforever.Qai.Database.Setup.csproj
+COPY ./src/Faforever.Qai.Discord/Faforever.Qai.Discord.csproj ./src/Faforever.Qai.Discord/Faforever.Qai.Discord.csproj
+COPY ./src/Faforever.Qai.Irc/Faforever.Qai.Irc.csproj ./src/Faforever.Qai.Irc/Faforever.Qai.Irc.csproj
+
+COPY ./tests/Faforever.Qai.Core.Tests/Faforever.Qai.Core.Tests.csproj ./tests/Faforever.Qai.Core.Tests/Faforever.Qai.Core.Tests.csproj
+
+# Install all necessary packages
+RUN dotnet restore
+
+COPY ./src ./src
+COPY ./tests ./tests
+
+RUN dotnet publish -c Release -o out
+COPY ./src/Faforever.Qai/Database out/Database
+
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
+WORKDIR /app 
+COPY --from=build /build/out ./
 ENTRYPOINT ["dotnet", "Faforever.Qai.dll"]


### PR DESCRIPTION
This way it's possible to create a faf-qai docker image even without having .net core installed.

Seems like the bot is using a sqlite database located in the /app/Database/ folder so that should probably be located on a Docker volume.




