### PR TITLE
New commands: !link|!wiki <searchString>, !hug <someone>

### DIFF
--- a/src/Faforever.Qai.Core/Commands.Context/CustomCommandContext.cs
+++ b/src/Faforever.Qai.Core/Commands.Context/CustomCommandContext.cs
@@ -24,5 +24,11 @@ namespace Faforever.Qai.Core.Commands.Context
 		/// <param name="message">Message to be sent back.</param>
 		/// <returns>Operation for this reply.</returns>
 		public abstract Task ReplyAsync(string message);
+		/// <summary>
+		/// An action (/me) sent back to the user
+		/// </summary>
+		/// <param name="action">Message to be sent back.</param>
+		/// <returns>Operation for this reply.</returns>
+		public abstract Task ActionAsync(string action);
 	}
 }

--- a/src/Faforever.Qai.Core/Commands.Context/DiscordCommandContext.cs
+++ b/src/Faforever.Qai.Core/Commands.Context/DiscordCommandContext.cs
@@ -35,5 +35,12 @@ namespace Faforever.Qai.Core.Commands.Context
 		{
 			await Channel.SendMessageAsync(message);
 		}
+
+		public override Task ActionAsync(string action)
+		{
+			//throw new NotImplementedException();
+
+			return Task.CompletedTask;
+		}
 	}
 }

--- a/src/Faforever.Qai.Core/Commands.Context/IRCCommandContext.cs
+++ b/src/Faforever.Qai.Core/Commands.Context/IRCCommandContext.cs
@@ -38,5 +38,19 @@ namespace Faforever.Qai.Core.Commands.Context
 				Client.SendMessage(RespondTo, message);
 			});
 		}
+
+		public override Task ActionAsync(string message)
+		{
+			return Task.Run(() =>
+			{
+				message = message.Replace("\n", " ");
+				IIrcMessageTarget? target = Channel;
+				if (target is null)
+					target = Author;
+
+				var actionMessage = IrcUtils.ActionMessage(message);
+				Client.SendMessage(target, actionMessage);
+			});
+		}
 	}
 }

--- a/src/Faforever.Qai.Core/Commands/Arguments/DiscordMemberCapsule.cs
+++ b/src/Faforever.Qai.Core/Commands/Arguments/DiscordMemberCapsule.cs
@@ -10,6 +10,8 @@ namespace Faforever.Qai.Core.Commands.Arguments
 {
 	public class DiscordMemberCapsule : IBotUserCapsule
 	{
+		public string Username => Member.Mention;
+
 		public DiscordMember Member { get; private set; }
 		public DiscordMemberCapsule(DiscordMember m)
 		{

--- a/src/Faforever.Qai.Core/Commands/Arguments/DiscordUserCapsule.cs
+++ b/src/Faforever.Qai.Core/Commands/Arguments/DiscordUserCapsule.cs
@@ -10,6 +10,7 @@ namespace Faforever.Qai.Core.Commands.Arguments
 {
 	public class DiscordUserCapsule : IBotUserCapsule
 	{
+		public string Username => User.Mention;
 		public DiscordUser User { get; private set; }
 		public DiscordUserCapsule(DiscordUser u)
 		{

--- a/src/Faforever.Qai.Core/Commands/Arguments/IBotUserCapsule.cs
+++ b/src/Faforever.Qai.Core/Commands/Arguments/IBotUserCapsule.cs
@@ -8,6 +8,6 @@ namespace Faforever.Qai.Core.Commands.Arguments
 {
 	public interface IBotUserCapsule
 	{
-		
+		string Username { get; }
 	}
 }

--- a/src/Faforever.Qai.Core/Commands/Arguments/IrcUserCapsule.cs
+++ b/src/Faforever.Qai.Core/Commands/Arguments/IrcUserCapsule.cs
@@ -10,7 +10,9 @@ namespace Faforever.Qai.Core.Commands.Arguments
 {
 	public class IrcUserCapsule : IBotUserCapsule
 	{
+		public string Username => User.NickName;
 		public IrcUser User { get; private set; }
+
 		public IrcUserCapsule(IrcUser u)
 		{
 			User = u;

--- a/src/Faforever.Qai.Core/Commands/Dual/Fun/HugCommand.cs
+++ b/src/Faforever.Qai.Core/Commands/Dual/Fun/HugCommand.cs
@@ -1,0 +1,33 @@
+using System.Threading.Tasks;
+
+using Faforever.Qai.Core.Commands.Arguments;
+using Faforever.Qai.Core.Commands.Context;
+
+using Qmmands;
+
+namespace Faforever.Qai.Core.Commands.Dual.Fun
+{
+	public class HugCommand : DualCommandModule
+	{
+		[Command("hug")]
+		[Description("Hug a user")]
+		public async Task HugCommandAsync(IBotUserCapsule? user = null)
+		{
+			string username = "";
+
+			if (user is not null)
+			{
+				username = user.Username;
+			}
+			else
+			{
+				if (Context is DiscordCommandContext dctx)
+					username = dctx.User.Mention;
+				else if (Context is IRCCommandContext ictx)
+					username = ictx.Author.NickName;
+			}
+
+			await Context.ActionAsync($" hugs {username}");
+		}
+	}
+}

--- a/src/Faforever.Qai.Core/Commands/Dual/Fun/TauntCommand.cs
+++ b/src/Faforever.Qai.Core/Commands/Dual/Fun/TauntCommand.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 
 using Faforever.Qai.Core.Commands.Arguments;
-using Faforever.Qai.Core.Commands.Context;
 using Faforever.Qai.Core.Commands.Exceptions;
 using Faforever.Qai.Core.Services.BotFun;
 
@@ -13,6 +12,7 @@ using Qmmands;
 
 namespace Faforever.Qai.Core.Commands.Dual.Fun
 {
+
 	public class TauntCommand : DualCommandModule
 	{
 		private readonly IBotFunService _botFun;
@@ -38,15 +38,12 @@ namespace Faforever.Qai.Core.Commands.Dual.Fun
 			{
 				prefix = ircUser.User.UserName;
 			}
-			else if(user is null)
-			{
-				if (Context is DiscordCommandContext dctx)
-					prefix = dctx.Client.CurrentUser.Mention;
-				else if (Context is IRCCommandContext ictx)
-					prefix = ictx.Client.UserName;
-			}
 
-			await Context.ReplyAsync($"{prefix}: {_botFun.GetRandomTaunt()}");
+			var taunt = _botFun.GetRandomTaunt();
+			if (!string.IsNullOrEmpty(prefix))
+				taunt = $"{prefix}: {taunt}";
+
+			await Context.ReplyAsync(taunt);
 		}
 	}
 }

--- a/src/Faforever.Qai.Core/Commands/Dual/Info/LinkCommand.cs
+++ b/src/Faforever.Qai.Core/Commands/Dual/Info/LinkCommand.cs
@@ -21,7 +21,7 @@ namespace Faforever.Qai.Core.Commands.Dual.Info
 
 		[Command("link")]
 		[Description("Search for a specifik link")]
-		public async Task UrlCommandAsync([Remainder] string search)
+		public async Task LinkCommandAsync([Remainder] string search)
 		{
 			var result = _urlService.FindUrl(search);
 
@@ -29,6 +29,18 @@ namespace Faforever.Qai.Core.Commands.Dual.Info
 				await Context.ReplyAsync($"{result.Title} {result.Url}");
 			else
 				await Context.ReplyAsync("Link not found");
+		}
+
+		[Command("wiki")]
+		[Description("Search for a specifik wiki link")]
+		public async Task WikiCommandAsync([Remainder] string search)
+		{
+			var result = _urlService.FindWikiUrl(search);
+
+			if (result is not null)
+				await Context.ReplyAsync($"{result.Title} {result.Url}");
+			else
+				await Context.ReplyAsync("Wiki link not found");
 		}
 	}
 }

--- a/src/Faforever.Qai.Core/Commands/Dual/Info/LinkCommand.cs
+++ b/src/Faforever.Qai.Core/Commands/Dual/Info/LinkCommand.cs
@@ -1,0 +1,34 @@
+using System.Threading.Tasks;
+
+using DSharpPlus.Entities;
+
+using Faforever.Qai.Core.Commands.Context;
+using Faforever.Qai.Core.Models;
+using Faforever.Qai.Core.Operations.Units;
+using Faforever.Qai.Core.Services;
+using Qmmands;
+
+namespace Faforever.Qai.Core.Commands.Dual.Info
+{
+	public class LinkCommand : DualCommandModule
+	{
+		private readonly IUrlService _urlService;
+
+		public LinkCommand(IUrlService urlService)
+		{
+			this._urlService = urlService;
+		}
+
+		[Command("link")]
+		[Description("Search for a specifik link")]
+		public async Task UrlCommandAsync([Remainder] string search)
+		{
+			var result = _urlService.FindUrl(search);
+
+			if (result is not null)
+				await Context.ReplyAsync($"{result.Title} {result.Url}");
+			else
+				await Context.ReplyAsync("Link not found");
+		}
+	}
+}

--- a/src/Faforever.Qai.Core/Extensions/ListExtensions.cs
+++ b/src/Faforever.Qai.Core/Extensions/ListExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 

--- a/src/Faforever.Qai.Core/IrcUtils.cs
+++ b/src/Faforever.Qai.Core/IrcUtils.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace Faforever.Qai.Core
+{
+	public static class IrcUtils
+	{
+		private static readonly IDictionary<char, char> quotedChars = new Dictionary<char, char>{
+			{'\0', '0'},
+			{'\n', 'n'},
+			{'\r', 'r'}
+		};
+
+		private const char ctcpEscapeChar = '\x5C';
+		private const char lowLevelEscapeChar = '\x10';
+		private const char taggedDataDelimeterChar = '\x001';
+
+		public static string ActionMessage(string text)
+		{
+			return taggedDataDelimeterChar + LowLevelQuote(CtcpQuote("ACTION " + text)) + taggedDataDelimeterChar;
+		}
+
+		private static string CtcpQuote(string value)
+		{
+			return Quote(value, ctcpEscapeChar);
+		}
+
+		private static string LowLevelQuote(string value)
+		{
+			return Quote(value, lowLevelEscapeChar);
+		}
+
+		private static string Quote(string value, char escapeChar)
+		{
+			var textBuilder = new StringBuilder(value.Length * 2);
+
+			for (var i = 0; i < value.Length; i++)
+			{
+				if (quotedChars.TryGetValue(value[i], out var curQuotedChar) || value[i] == escapeChar)
+				{
+					textBuilder.Append(escapeChar);
+					textBuilder.Append(curQuotedChar);
+				}
+				else
+				{
+					textBuilder.Append(value[i]);
+				}
+			}
+
+			return textBuilder.ToString();
+		}
+	}
+
+}

--- a/src/Faforever.Qai.Core/Levenshtein.cs
+++ b/src/Faforever.Qai.Core/Levenshtein.cs
@@ -1,0 +1,96 @@
+/*
+https://github.com/DanHarltey/Fastenshtein/blob/master/src/Fastenshtein/Levenshtein.cs
+
+The MIT License (MIT)
+
+Copyright(c) 2017 DanHartley
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Collections.Generic;
+
+namespace Faforever.Qai.Core
+{
+	public partial class Levenshtein
+	{
+		/// <summary>
+		/// Compares the two values to find the minimum Levenshtein distance. 
+		/// Thread safe.
+		/// </summary>
+		/// <returns>Difference. 0 complete match.</returns>
+		public static int Distance(string value1, string value2)
+		{
+			if (value2.Length == 0)
+			{
+				return value1.Length;
+			}
+
+			int[] costs = new int[value2.Length];
+
+			// Add indexing for insertion to first row
+			for (int i = 0; i < costs.Length;)
+			{
+				costs[i] = ++i;
+			}
+
+			for (int i = 0; i < value1.Length; i++)
+			{
+				// cost of the first index
+				int cost = i;
+				int previousCost = i;
+
+				// cache value for inner loop to avoid index lookup and bonds checking, profiled this is quicker
+				char value1Char = value1[i];
+
+				for (int j = 0; j < value2.Length; j++)
+				{
+					int currentCost = cost;
+
+					// assigning this here reduces the array reads we do, improvement of the old version
+					cost = costs[j];
+
+					if (value1Char != value2[j])
+					{
+						if (previousCost < currentCost)
+						{
+							currentCost = previousCost;
+						}
+
+						if (cost < currentCost)
+						{
+							currentCost = cost;
+						}
+
+						++currentCost;
+					}
+
+					/* 
+                     * Improvement on the older versions.
+                     * Swapping the variables here results in a performance improvement for modern intel CPU’s, but I have no idea why?
+                     */
+					costs[j] = currentCost;
+					previousCost = currentCost;
+				}
+			}
+
+			return costs[costs.Length - 1];
+		}
+	}
+}

--- a/src/Faforever.Qai.Core/QCommandsHandler.cs
+++ b/src/Faforever.Qai.Core/QCommandsHandler.cs
@@ -104,6 +104,7 @@ namespace Faforever.Qai.Core
 					return false;
 				}
 			}
+
 			// ... otherwise they can run the command.
 			return true;
 		}

--- a/src/Faforever.Qai.Core/Services/UrlService.cs
+++ b/src/Faforever.Qai.Core/Services/UrlService.cs
@@ -1,0 +1,44 @@
+using Faforever.Qai.Core.Structures.Configurations;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Faforever.Qai.Core.Services
+{
+	public interface IUrlService
+	{
+		public UrlEntry? FindUrl(string search);
+	}
+
+	public class UrlConfiguration
+	{
+		public Dictionary<string, UrlEntry> Urls { get; set; } = new();
+		public Dictionary<string, string> Synonymes { get; set; } = new();
+	}
+
+	public class UrlEntry
+	{
+		public string Title { get; set; } = default!;
+		public string Url { get; set; } = default!;
+	}
+
+	public class UrlService : IUrlService
+	{
+		private UrlConfiguration _urlConfig;
+
+		public UrlService(UrlConfiguration wikiConfig)
+		{
+			this._urlConfig = wikiConfig;
+		}
+
+		public UrlEntry? FindUrl(string search)
+		{
+			if (_urlConfig.Urls.TryGetValue(search, out var entry))
+				return entry;
+
+			var first = _urlConfig.Urls.Select(kv => new { Entry = kv.Value, Distance = Levenshtein.Distance(kv.Key, search) }).OrderBy(lv => lv.Distance).FirstOrDefault(lv => lv.Distance < 5);
+
+			return first?.Entry;
+		}
+	}
+}

--- a/src/Faforever.Qai.Core/Services/UrlService.cs
+++ b/src/Faforever.Qai.Core/Services/UrlService.cs
@@ -1,19 +1,24 @@
 using Faforever.Qai.Core.Structures.Configurations;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Serialization;
 
 namespace Faforever.Qai.Core.Services
 {
 	public interface IUrlService
 	{
 		public UrlEntry? FindUrl(string search);
+		public UrlEntry? FindWikiUrl(string search);
 	}
 
 	public class UrlConfiguration
 	{
+		[JsonProperty("urls")]
 		public Dictionary<string, UrlEntry> Urls { get; set; } = new();
-		public Dictionary<string, string> Synonymes { get; set; } = new();
+		[JsonProperty("wiki_urls")]
+		public Dictionary<string, UrlEntry> WikiUrls { get; set; } = new();
 	}
 
 	public class UrlEntry
@@ -33,10 +38,20 @@ namespace Faforever.Qai.Core.Services
 
 		public UrlEntry? FindUrl(string search)
 		{
-			if (_urlConfig.Urls.TryGetValue(search, out var entry))
+			return FindUrlEntry(_urlConfig.Urls, search);
+		}
+
+		public UrlEntry? FindWikiUrl(string search)
+		{
+			return FindUrlEntry(_urlConfig.WikiUrls, search);
+		}
+
+		private static UrlEntry? FindUrlEntry(IDictionary<string, UrlEntry> urls, string search)
+		{
+			if (urls.TryGetValue(search, out var entry))
 				return entry;
 
-			var first = _urlConfig.Urls.Select(kv => new { Entry = kv.Value, Distance = Levenshtein.Distance(kv.Key, search) }).OrderBy(lv => lv.Distance).FirstOrDefault(lv => lv.Distance < 5);
+			var first = urls.Select(kv => new { Entry = kv.Value, Distance = Levenshtein.Distance(kv.Key, search) }).OrderBy(lv => lv.Distance).FirstOrDefault(lv => lv.Distance < 5);
 
 			return first?.Entry;
 		}

--- a/src/Faforever.Qai.Irc/QaIrc.cs
+++ b/src/Faforever.Qai.Irc/QaIrc.cs
@@ -74,7 +74,7 @@ namespace Faforever.Qai.Irc
 				return;
 			}
 			
-			IRCCommandContext ctx = new IRCCommandContext(_client.LocalUser, eventArgs.Source.Name, channeluser.User, eventArgs.Text, "!", _services);
+			IRCCommandContext ctx = new IRCCommandContext(_client.LocalUser, eventArgs.Source.Name, channeluser.User, eventArgs.Text, "!", _services, channel);
 			await _commandHandler.MessageRecivedAsync(ctx, eventArgs.Text);
 
 			await _relay.IRC_MessageReceived(channel.Name, eventArgs.Source.Name, eventArgs.Text);

--- a/src/Faforever.Qai/Config/url_config.json
+++ b/src/Faforever.Qai/Config/url_config.json
@@ -1,0 +1,21 @@
+{
+  "urls": {
+    "faf": { "title":"FAF main page!", "url": "https://www.faforever.com" },
+    "forum": { "title": "FAF Forum!", "url": "https://forum.faforever.com" },
+    "support": { "title": "Tech support!", "url": "https://forums.faforever.com/viewforum.php?f=3" },
+    "wiki": { "title": "FAF Wiki!", "url": "https://wiki.faforever.com/index.php?title=Main_Page" },
+    "news": { "title": "What's new?", "url": "https://www.faforever.com/news/" },
+    "dev": { "title": "Tumblr Development Feed", "url": "https://faforeverdevblog.tumblr.com/" },
+    "discord": { "title": "FAF Official Discord server", "url": "https://discord.gg/hgvj6Af" },
+    "replay": { "title": "Replay", "url": "https://replay.faforever.com/ID" },
+    "unitsdb": { "title": "Check out", "url": "https://direct.faforever.com/faf/unitsDB/ and spooky.github.io/unitdb/#/" },
+    "namechange": { "title": "Change username", "url": "https://faforever.com/account/username/change" },
+    "clans": { "title": "FAF clans!", "url": "https://clans.faforever.com" },
+    "github": { "title": "FAF on Github", "url": "https://github.com/FAForever" },
+    "youtube": { "title": "FAF Youtube", "url": "https://www.youtube.com/channel/UCkAWiUu4QE172kv-ZuyR42w" },
+    "replayparser": { "title": "Replay parser", "url": "https://fafafaf.bitbucket.io/" },
+    "tumblr": { "title": "FAF Reactions on tumblr", "url": "https://fafreactions.tumblr.com/" },
+    "wwpc": { "title": "World Wide People's Championship", "url": "http://forums.faforever.com/viewtopic.php?f=26&t=13780" },
+    "changelog": { "title": "Balance patchnotes", "url": "https://content.faforever.com/patchnotes/" }
+  },
+}

--- a/src/Faforever.Qai/Config/url_config.json
+++ b/src/Faforever.Qai/Config/url_config.json
@@ -1,21 +1,198 @@
 {
   "urls": {
-    "faf": { "title":"FAF main page!", "url": "https://www.faforever.com" },
-    "forum": { "title": "FAF Forum!", "url": "https://forum.faforever.com" },
-    "support": { "title": "Tech support!", "url": "https://forums.faforever.com/viewforum.php?f=3" },
-    "wiki": { "title": "FAF Wiki!", "url": "https://wiki.faforever.com/index.php?title=Main_Page" },
-    "news": { "title": "What's new?", "url": "https://www.faforever.com/news/" },
-    "dev": { "title": "Tumblr Development Feed", "url": "https://faforeverdevblog.tumblr.com/" },
-    "discord": { "title": "FAF Official Discord server", "url": "https://discord.gg/hgvj6Af" },
-    "replay": { "title": "Replay", "url": "https://replay.faforever.com/ID" },
-    "unitsdb": { "title": "Check out", "url": "https://direct.faforever.com/faf/unitsDB/ and spooky.github.io/unitdb/#/" },
-    "namechange": { "title": "Change username", "url": "https://faforever.com/account/username/change" },
-    "clans": { "title": "FAF clans!", "url": "https://clans.faforever.com" },
-    "github": { "title": "FAF on Github", "url": "https://github.com/FAForever" },
-    "youtube": { "title": "FAF Youtube", "url": "https://www.youtube.com/channel/UCkAWiUu4QE172kv-ZuyR42w" },
-    "replayparser": { "title": "Replay parser", "url": "https://fafafaf.bitbucket.io/" },
-    "tumblr": { "title": "FAF Reactions on tumblr", "url": "https://fafreactions.tumblr.com/" },
-    "wwpc": { "title": "World Wide People's Championship", "url": "http://forums.faforever.com/viewtopic.php?f=26&t=13780" },
-    "changelog": { "title": "Balance patchnotes", "url": "https://content.faforever.com/patchnotes/" }
+    "faf": {
+      "title": "FAF main page!",
+      "url": "https://www.faforever.com"
+    },
+    "forum": {
+      "title": "FAF Forum!",
+      "url": "https://forum.faforever.com"
+    },
+    "support": {
+      "title": "Tech support!",
+      "url": "https://forums.faforever.com/viewforum.php?f=3"
+    },
+    "wiki": {
+      "title": "FAF Wiki!",
+      "url": "https://wiki.faforever.com/index.php?title=Main_Page"
+    },
+    "news": {
+      "title": "What's new?",
+      "url": "https://www.faforever.com/news/"
+    },
+    "dev": {
+      "title": "Tumblr Development Feed",
+      "url": "https://faforeverdevblog.tumblr.com/"
+    },
+    "discord": {
+      "title": "FAF Official Discord server",
+      "url": "https://discord.gg/hgvj6Af"
+    },
+    "replay": {
+      "title": "Replay",
+      "url": "https://replay.faforever.com/ID"
+    },
+    "unitsdb": {
+      "title": "Check out",
+      "url": "https://direct.faforever.com/faf/unitsDB/ and spooky.github.io/unitdb/#/"
+    },
+    "namechange": {
+      "title": "Change username",
+      "url": "https://faforever.com/account/username/change"
+    },
+    "clans": {
+      "title": "FAF clans!",
+      "url": "https://clans.faforever.com"
+    },
+    "github": {
+      "title": "FAF on Github",
+      "url": "https://github.com/FAForever"
+    },
+    "youtube": {
+      "title": "FAF Youtube",
+      "url": "https://www.youtube.com/channel/UCkAWiUu4QE172kv-ZuyR42w"
+    },
+    "replayparser": {
+      "title": "Replay parser",
+      "url": "https://fafafaf.bitbucket.io/"
+    },
+    "tumblr": {
+      "title": "FAF Reactions on tumblr",
+      "url": "https://fafreactions.tumblr.com/"
+    },
+    "wwpc": {
+      "title": "World Wide People's Championship",
+      "url": "http://forums.faforever.com/viewtopic.php?f=26&t=13780"
+    },
+    "changelog": {
+      "title": "Balance patchnotes",
+      "url": "https://content.faforever.com/patchnotes/"
+    }
   },
+  "wiki_urls": {
+    "AI": {
+      "title": "Guide to AI modding:",
+      "url": "https://wiki.faforever.com/index.php?title=AI_Modding"
+    },
+    "adjacency": {
+      "title": "Information on the adjacency bonus:",
+      "url": "https://wiki.faforever.com/index.php?title=Adjacency_Bonus"
+    },
+    "avatars": {
+      "title": "Avatars and how to get them:",
+      "url": "https://wiki.faforever.com/index.php?title=FAF_chat#Avatars"
+    },
+    "balance": {
+      "title": "How game quality works:",
+      "url": "https://wiki.faforever.com/index.php?title=The_game_balance_index"
+    },
+    "chat": {
+      "title": "The FAF chat tab:",
+      "url": "https://wiki.faforever.com/index.php?title=FAF_chat"
+    },
+    "connection": {
+      "title": "Help with connection issues:",
+      "url": "https://wiki.faforever.com/index.php?title=Connection_issues_and_solutions"
+    },
+    "coop": {
+      "title": "The coop missions and campaign:",
+      "url": "https://wiki.faforever.com/index.php?title=Coop_Missions"
+    },
+    "engymod": {
+      "title": "The integrated Engy Mod:",
+      "url": "https://wiki.faforever.com/index.php?title=Game_Modifications_(Mods)#Engy_Mod"
+    },
+    "galacticwar": {
+      "title": "Galactic war and playing it:",
+      "url": "https://wiki.faforever.com/index.php?title=Galactic_War"
+    },
+    "hostgame": {
+      "title": "How to host and join games:",
+      "url": "https://wiki.faforever.com/index.php?title=Host_and_join_games"
+    },
+    "hotbuild": {
+      "title": "Setting up and using HotBuild:",
+      "url": "https://wiki.faforever.com/index.php?title=Game_Modifications_(Mods)#Gaz_UI_and_Hotbuild"
+    },
+    "ladder": {
+      "title": "Info on the FAF 1v1 ladder:",
+      "url": "https://wiki.faforever.com/index.php?title=The_Ladder"
+    },
+    "ladderpool": {
+      "title": "The Current Ladder map pool:",
+      "url": "https://wiki.faforever.com/index.php?title=Ladder_Map_Pool"
+    },
+    "leaderboards": {
+      "title": "The 1v1 Ladder Leaderboards:",
+      "url": "https://wiki.faforever.com/index.php?title=Leaderboards_and_Rating"
+    },
+    "mapeditor": {
+      "title": "Getting and using the map editor:",
+      "url": "https://wiki.faforever.com/index.php?title=Map_Editor"
+    },
+    "irc": {
+      "title": "Connecting to and using FAF chat with IRC:",
+      "url": "https://wiki.faforever.com/index.php?title=Chat_/_IRC_server"
+    },
+    "maps": {
+      "title": "The FAF Map Vault:",
+      "url": "https://wiki.faforever.com/index.php?title=Map_Vault"
+    },
+    "mapdownload": {
+      "title": "How to download maps:",
+      "url": "https://wiki.faforever.com/index.php?title=Map_Vault#3._Download_button"
+    },
+    "moderators": {
+      "title": "List of FAF moderators:",
+      "url": "https://wiki.faforever.com/index.php?title=User_Groups#FAF_Moderators"
+    },
+    "mods": {
+      "title": "How mods work with FAF:",
+      "url": "https://wiki.faforever.com/index.php?title=Game_Modifications_(Mods)"
+    },
+    "mumble": {
+      "title": "Using Mumble with FAF:",
+      "url": "https://wiki.faforever.com/index.php?title=Voicechat_(Mumble)"
+    },
+    "patches": {
+      "title": "All the patch changelogs:",
+      "url": "https://wiki.faforever.com/index.php?title=Main_Page#Patch_Change_Logs"
+    },
+    "replays": {
+      "title": "The FAF replay vault:",
+      "url": "https://wiki.faforever.com/index.php?title=Replay_Vault_%26_Live_Games"
+    },
+    "rating": {
+      "title": "How rating works in FAF:",
+      "url": "https://wiki.faforever.com/index.php?title=Global_Ranking"
+    },
+    "rules": {
+      "title": "The FAF client and forum rules:",
+      "url": "https://wiki.faforever.com/index.php?title=FAF_Client/Forum_Rules"
+    },
+    "school": {
+      "title": "FAF Dev School, the simple guide to all of FAF's code:",
+      "url": "https://wiki.faforever.com/index.php?title=FAF_Development_School"
+    },
+    "splitattack": {
+      "title": "Using Split attack in game:",
+      "url": "https://wiki.faforever.com/index.php?title=Game_Modifications_(Mods)#Split_Attack"
+    },
+    "trainers": {
+      "title": "List of personal trainers in FAF:",
+      "url": "https://wiki.faforever.com/index.php?title=User_Groups#Trainers"
+    },
+    "trueskill": {
+      "title": "Trueskill explained:",
+      "url": "https://wiki.faforever.com/index.php?title=How_Trueskill_works"
+    },
+    "tutorials": {
+      "title": "Help with learning how to play:",
+      "url": "https://wiki.faforever.com/index.php?title=Learning_SupCom"
+    },
+    "adaptivemap": {
+      "title": "Learn more about the adaptive maps from the Ultimate series",
+      "url": "https://wiki.faforever.com/index.php?title=Adaptive_Maps"
+    }
+  }
 }

--- a/src/Faforever.Qai/Startup.cs
+++ b/src/Faforever.Qai/Startup.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -91,13 +90,11 @@ namespace Faforever.Qai
 				Directory.CreateDirectory("Database");
 #endif
 
-			BotFunConfiguration botFunConfig;
-			using (FileStream fs = new(Path.Join("Config", "games_config.json"), FileMode.Open))
-			{
-				using StreamReader sr = new(fs);
-				var json = sr.ReadToEnd();
-				botFunConfig = JsonConvert.DeserializeObject<BotFunConfiguration>(json);
-			}
+			string json = File.ReadAllText(Path.Join("Config", "games_config.json"));
+			var botFunConfig = JsonConvert.DeserializeObject<BotFunConfiguration>(json);
+			
+			json = File.ReadAllText(Path.Join("Config", "url_config.json"));
+			var urlConfig = JsonConvert.DeserializeObject<UrlConfiguration>(json);
 
 			TwitchClientConfig twitchCfg = new()
 			{
@@ -134,6 +131,7 @@ namespace Faforever.Qai
 				.AddSingleton(typeof(TwitchClientConfig), twitchCfg)
 				// Operation Service Registration
 				.AddSingleton<IBotFunService>(new BotFunService(botFunConfig))
+				.AddSingleton<IUrlService>(new UrlService(urlConfig))
 				.AddSingleton<DiscordEventHandler>()
 				.AddSingleton<AccountLinkService>()
 				.AddTransient<IFetchPlayerStatsOperation, ApiFetchPlayerStatsOperation>()


### PR DESCRIPTION
Add support for `!link <searchString>` - Command to search for a known, FAF-related URL. 
Fallback to fuzzy search (levenshtein-distance) if exact match isn't found.

(maybe should move the url storage to sqlite in the future to make it possible for admins to register new URLs without restart)