### PR TITLE
Fix !map with spaces

### DIFF
--- a/src/Faforever.Qai.Core/Operations/FafApi/FafApiClient.cs
+++ b/src/Faforever.Qai.Core/Operations/FafApi/FafApiClient.cs
@@ -138,9 +138,7 @@ namespace Faforever.Qai.Core.Operations.FafApi
 
             // Add quotes for string values but prevent double-quoting
             if (value is string && !stringValue.StartsWith('"') && !stringValue.EndsWith('"'))
-            {
                 stringValue = $"\"{stringValue}\"";
-            }
 
             // URL encoding is handled by QueryHelpers.AddQueryString in ToString() method
             return stringValue;

--- a/src/Faforever.Qai.Core/Operations/FafApi/FafApiClient.cs
+++ b/src/Faforever.Qai.Core/Operations/FafApi/FafApiClient.cs
@@ -136,7 +136,14 @@ namespace Faforever.Qai.Core.Operations.FafApi
                 _ => stringValue
             };
 
-            return HttpUtility.UrlEncode(stringValue);
+            // Add quotes for string values but prevent double-quoting
+            if (value is string && !stringValue.StartsWith('"') && !stringValue.EndsWith('"'))
+            {
+                stringValue = $"\"{stringValue}\"";
+            }
+
+            // URL encoding is handled by QueryHelpers.AddQueryString in ToString() method
+            return stringValue;
         }
         public ApiQuery<T> Where<TValue>(Expression<Func<T, TValue>> expr, WhereOp opStr, TValue value)
         {


### PR DESCRIPTION
fixes #129 
The issue was in how API link was formed: it encoded spaces to "+", end applied another URL encoding, leading to the link like
`'map?include=versions,author&filter=displayName%3D%3D*open%2Bpalms*&sort=-gamesPlayed'`
which is not really correct API link.
after decoding: 
`'map?include=versions,author&filter=displayName==*open+palms*&sort=-gamesPlayed'`

i have no idea why there are "+" there instead of spaces, and why there is no quotes here (which seems to be used in old JS bot and correct)
but i just assume that there are **_some_** reasons for it, so i made surgical changes which only affects displayName param.

now the link is correctly handles such map by having a link like
`map?include=versions,author&filter=displayName%3D%3D%22*open%20palms*%22&sort=-gamesPlayed`
after decoding: `'map?include=versions,author&filter=displayName=="*open palms*"&sort=-gamesPlayed'`
Probably can be done better (maybe some other params also affected), but atleast this feels like not break anything,

+ Fixes maps with spaces (i tested in my personal discord server)
+ Probably doesnt break anything (15 tests, 8 OK, 7 skipped, take it or leave it)
